### PR TITLE
Adding an automated option for Kaggle endpoint authentication

### DIFF
--- a/activities/data_source/integration/1_Lab_datasource_integration_Kaggle.ipynb
+++ b/activities/data_source/integration/1_Lab_datasource_integration_Kaggle.ipynb
@@ -4,7 +4,8 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "authorship_tag": "ABX9TyNiGqyRPQZBzJkz+Y2SoFOL",
+      "toc_visible": true,
+      "authorship_tag": "ABX9TyMDSjTyuq68wSG4Z7+vfcMu",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -23,7 +24,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/main/activities/data_source/integration/1_Lab_datasource_integration_Kaggle.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/solver-Martin-Datasource-Integration/activities/data_source/integration/1_Lab_datasource_integration_Kaggle.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -46,35 +47,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Ky7WR4NskgGV",
-        "outputId": "4e93c888-95e7-4902-a291-b3cbadccf450"
+        "id": "Ky7WR4NskgGV"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: kaggle in /usr/local/lib/python3.10/dist-packages (1.6.12)\n",
-            "Requirement already satisfied: six>=1.10 in /usr/local/lib/python3.10/dist-packages (from kaggle) (1.16.0)\n",
-            "Requirement already satisfied: certifi>=2023.7.22 in /usr/local/lib/python3.10/dist-packages (from kaggle) (2024.2.2)\n",
-            "Requirement already satisfied: python-dateutil in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.8.2)\n",
-            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.31.0)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from kaggle) (4.66.2)\n",
-            "Requirement already satisfied: python-slugify in /usr/local/lib/python3.10/dist-packages (from kaggle) (8.0.4)\n",
-            "Requirement already satisfied: urllib3 in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.0.7)\n",
-            "Requirement already satisfied: bleach in /usr/local/lib/python3.10/dist-packages (from kaggle) (6.1.0)\n",
-            "Requirement already satisfied: webencodings in /usr/local/lib/python3.10/dist-packages (from bleach->kaggle) (0.5.1)\n",
-            "Requirement already satisfied: text-unidecode>=1.3 in /usr/local/lib/python3.10/dist-packages (from python-slugify->kaggle) (1.3)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->kaggle) (3.3.2)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->kaggle) (3.7)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "! pip install kaggle"
       ]
@@ -85,13 +62,22 @@
         "## Load Your Kaggle API Endpoint Key\n",
         "Next, you will need to provide access to Kaggle API endpoints to this notebook.\n",
         "\n",
-        "This requires you to upload the kaggle.json file from your Kaggle Account to this notebook's session storage /content.\n",
-        "\n",
-        "Refer to the [How to Load Kaggle Datasets Directly Into Google Colab?](https://www.analyticsvidhya.com/blog/2021/06/how-to-load-kaggle-datasets-directly-into-google-colab/)\n",
-        "blog for more details."
+        "This requires you to upload the kaggle.json file from your Kaggle Account to this notebook's session storage /content."
       ],
       "metadata": {
         "id": "xT_CFPPknZ3N"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Option 1: Manually Uploading the Kaggle API Endpoint Key\n",
+        "\n",
+        "Refer to the [How to Load Kaggle Datasets Directly Into Google Colab?](https://www.analyticsvidhya.com/blog/2021/06/how-to-load-kaggle-datasets-directly-into-google-colab/)\n",
+        "blog for more details with this method."
+      ],
+      "metadata": {
+        "id": "OlfuTpLwHyNh"
       }
     },
     {
@@ -100,22 +86,10 @@
         "! mkdir ~/.kaggle"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Wd2l8RPgl2PX",
-        "outputId": "cedca9a8-a6a4-469b-82ee-fb1f5504ddb3"
+        "id": "Wd2l8RPgl2PX"
       },
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "mkdir: cannot create directory ‘/root/.kaggle’: File exists\n"
-          ]
-        }
-      ]
+      "execution_count": 2,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -125,7 +99,7 @@
       "metadata": {
         "id": "qMCTYh5Ll4S1"
       },
-      "execution_count": 7,
+      "execution_count": 3,
       "outputs": []
     },
     {
@@ -136,8 +110,52 @@
       "metadata": {
         "id": "WLE-5HSol7FW"
       },
-      "execution_count": 8,
+      "execution_count": 4,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Option 2: Using Google Drive as Kaggle API Endpoint Key Storage\n",
+        "Refer to the [Importing Datasets from Kaggle to Google Colab](https://saturncloud.io/blog/importing-datasets-from-kaggle-to-google-colab/) blog for more details with this method."
+      ],
+      "metadata": {
+        "id": "UMM4jusIHFCJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive')"
+      ],
+      "metadata": {
+        "id": "izSxomoyHGVg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "os.environ['KAGGLE_CONFIG_DIR'] = '/content/drive/MyDrive/kaggle'"
+      ],
+      "metadata": {
+        "id": "Wgq1DZawHLby"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Load Your Kaggle Dataset\n",
+        "You may now access the datasets or specific files within them as follows. The -f option flag takes in the specific file you want to access."
+      ],
+      "metadata": {
+        "id": "dlx5fdreHSyx"
+      }
     },
     {
       "cell_type": "code",
@@ -145,26 +163,28 @@
         "! kaggle datasets download martinjohnhborja/san-francisco-film-locations -f Film_Locations_in_San_Francisco_20240504.csv"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "yQcTTlVVl8ed",
-        "outputId": "6de66848-25b9-48b0-eb5f-f4ffb6034d95"
+        "id": "yQcTTlVVl8ed"
       },
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Dataset URL: https://www.kaggle.com/datasets/martinjohnhborja/san-francisco-film-locations\n",
-            "License(s): unknown\n",
-            "Downloading Film_Locations_in_San_Francisco_20240504.csv to /content\n",
-            "  0% 0.00/425k [00:00<?, ?B/s]\n",
-            "100% 425k/425k [00:00<00:00, 69.3MB/s]\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Conclusion\n",
+        "Congratulations! You are now capable of loading datasets from Kaggle to Google Colab.\n",
+        "<br>\n",
+        "<br>\n",
+        "<br>\n",
+        "<hr>\n",
+        "\n",
+        "<h4 align=\"center\"> © Martin John Hilario Borja 2024. All rights reserved. </h4>\n",
+        "\n",
+        "<p>"
+      ],
+      "metadata": {
+        "id": "nLsQO1TDI-Mh"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description of changes
This change adds an option that stores the kaggle.json key in Google Drive instead of manually uploading to each Google Colab notebook session.

# Issue number
Closes https://github.com/solver-Mart1n/data-science/issues/98

# PR Checklist
- [x] Verified code functionality
- [x] Manual code review*