### PR TITLE
[Eco-Fix] Point Google Colab URL to `main`

### DIFF
--- a/reference/ibm_ds/language/python/data_analysis/DA0101EN_2_Review_Data_Wrangling_20231003_1696291200_jupyterlite.ipynb
+++ b/reference/ibm_ds/language/python/data_analysis/DA0101EN_2_Review_Data_Wrangling_20231003_1696291200_jupyterlite.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/new_capability/reference/ibm_ds/language/python/data_analysis/DA0101EN_2_Review_Data_Wrangling_20231003_1696291200_jupyterlite.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/main/reference/ibm_ds/language/python/data_analysis/DA0101EN_2_Review_Data_Wrangling_20231003_1696291200_jupyterlite.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
# Description of changes
This change fixes the Google Colab URL reference by pointing to `main` branch.

# Issue number
Closes #123

# PR Checklist
- [x] Verified code functionality
- [x] Manual code review*