### PR TITLE
[Eco-Fix] Point Google Colab URL to `main`

### DIFF
--- a/reference/ibm_ds/language/python/data_analysis/Model_Evaluation_and_Refinement_cars.ipynb
+++ b/reference/ibm_ds/language/python/data_analysis/Model_Evaluation_and_Refinement_cars.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/model-eval-refine/data-science/reference/ibm_ds/language/python/data_analysis/Model_Evaluation_and_Refinement_cars.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/solver-Mart1n/data-science/blob/main/data-science/reference/ibm_ds/language/python/data_analysis/Model_Evaluation_and_Refinement_cars.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
This change addresses the Google Colab URL `main` issue when saving to a github branch other than `main`.

# Issue number
Closes #6

# PR Checklist
- [x] Verified code functionality
- [x] Manual code review*